### PR TITLE
Fix/ingest consumers and retension days

### DIFF
--- a/.env
+++ b/.env
@@ -1,5 +1,5 @@
 COMPOSE_PROJECT_NAME=sentry-self-hosted
-SENTRY_EVENT_RETENTION_DAYS=90
+SENTRY_EVENT_RETENTION_DAYS=14
 # You can either use a port number or an IP:PORT combo for SENTRY_BIND
 # See https://docs.docker.com/compose/compose-file/#ports for more
 SENTRY_BIND=9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -369,13 +369,13 @@ services:
     command: run worker
   events-consumer:
     <<: *sentry_defaults
-    command: run consumer ingest-events --consumer-group ingest-consumer
+    command: run consumer ingest-events --consumer-group ingest-consumer --concurrency 200 --max-batch-size 1000
   attachments-consumer:
     <<: *sentry_defaults
-    command: run consumer ingest-attachments --consumer-group ingest-consumer
+    command: run consumer ingest-attachments --consumer-group ingest-consumer --concurrency 200 --max-batch-size 1000
   transactions-consumer:
     <<: *sentry_defaults
-    command: run consumer ingest-transactions --consumer-group ingest-consumer
+    command: run consumer ingest-transactions --consumer-group ingest-consumer --concurrency 200 --max-batch-size 1000
   metrics-consumer:
     <<: *sentry_defaults
     command: run consumer ingest-metrics --consumer-group metrics-consumer


### PR DESCRIPTION


<!-- Describe your PR here. -->

# Overview

- ingest-consumer groupに `max_batch_size`, `concurrency`の設定を追加しました
- retension_daysを90日から14日に変更しました

<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
