### PR TITLE
RedisとPostgreSQLをmackerel-agentから観測するためにportをホストから見られるようにする

### DIFF
--- a/compose.override.production.yml
+++ b/compose.override.production.yml
@@ -2,6 +2,12 @@ x-restart-policy: &restart_policy
   restart: unless-stopped
 
 services:
+  redis:
+    ports:
+      - '6379:6379'
+  postgres:
+    ports:
+      - '5432:5432'
   https-portal:
     <<: *restart_policy
     image: steveltn/https-portal:1

--- a/compose.override.staging.yml
+++ b/compose.override.staging.yml
@@ -2,6 +2,12 @@ x-restart-policy: &restart_policy
   restart: unless-stopped
 
 services:
+  redis:
+    ports:
+      - '6379:6379'
+  postgres:
+    ports:
+      - '5432:5432'
   https-portal:
     <<: *restart_policy
     image: steveltn/https-portal:1


### PR DESCRIPTION

<!-- Describe your PR here. -->
RedisとPostgreSQLをmackerel-agentから観測するためにportをホストから見られるようにする


<!--

  Sentry employees and contractors can delete or ignore the following.

-->

### Legal Boilerplate

Look, I get it. The entity doing business as "Sentry" was incorporated in the State of Delaware in 2015 as Functional Software, Inc. and is gonna need some rights from me in order to utilize my contributions in this here PR. So here's the deal: I retain all rights, title and interest in and to my contributions, and by keeping this boilerplate intact I confirm that Sentry can use, modify, copy, and redistribute my contributions, under Sentry's choice of terms.
